### PR TITLE
use the api instead of scraping the wiki

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
 const get = require('got')
 const URL = require('url')
+const unwantedProps = [
+  'content_urls', 
+  'dir', 
+  'revision', 
+  'tid', 
+  'timestamp', 
+  'pageid', 
+  'namespace', 
+  'titles', 
+  'api_urls'
+]
 
 async function lookup (query, locale = 'en') {
   const url = URL.format({
@@ -16,7 +27,11 @@ async function lookup (query, locale = 'en') {
     return null
   }
 
-  return Object.assign({}, body, {query: query})
+  unwantedProps.forEach(prop => {
+    delete body[prop]
+  })
+
+  return Object.assign({}, {query: query},  body)
 }
 
 module.exports = lookup

--- a/index.js
+++ b/index.js
@@ -5,16 +5,14 @@ async function lookup (query, locale = 'en') {
   const url = URL.format({
     protocol: 'https',
     hostname: `${locale}.wikipedia.org`,
-    pathname: `/api/rest_v1/page/summary/${query}`
+    pathname: `/api/rest_v1/page/summary/${encodeURIComponent(query)}`
   })
-  console.log(url)
 
   let body
   try {
     const res = await get(url, {json: true})
     body = res.body
   } catch (err) {
-    console.error(err)
     return null
   }
 

--- a/index.js
+++ b/index.js
@@ -1,26 +1,24 @@
 const get = require('got')
 const URL = require('url')
-const cheerio = require('cheerio')
 
 async function lookup (query, locale = 'en') {
   const url = URL.format({
     protocol: 'https',
     hostname: `${locale}.wikipedia.org`,
-    pathname: `/wiki/${query}`
+    pathname: `/api/rest_v1/page/summary/${query}`
   })
+  console.log(url)
 
   let body
   try {
-    const res = await get(url)
+    const res = await get(url, {json: true})
     body = res.body
   } catch (err) {
+    console.error(err)
     return null
   }
 
-  const $ = cheerio.load(body)
-  const html = $('#mw-content-text p').first().html()
-  const text = $('#mw-content-text p').first().text()
-  return {query, html, text}
+  return Object.assign({}, body, {query: query})
 }
 
 module.exports = lookup

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "cheerio": "^1.0.0-rc.2",
-    "got": "^8.1.0",
-    "wordwrap": "^1.0.0"
+    "got": "^8.1.0"
   },
   "devDependencies": {
     "jest": "^22.3.0",

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,24 @@ The result looks like this:
 
 ```js
 {
-  query: 'somatology',
-  html: '<p> ...same as text but with markup preserved... </p>',
-  text: 'English\nEtymology\nFrom soma (body) +‎ -ology.\nNoun\nsomatology (usually uncountable, plural somatologies)\nThe study of the physical nature of human beings.\nDerived terms\nanthroposomatology\n'
+  query: "pomology",
+  type: "standard",
+  title: "Pomology",
+  displaytitle: "Pomology",
+  thumbnail: {
+    source: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/Poire_Willermoz.jpg/241px-Poire_Willermoz.jpg",
+    width: 241,
+    height: 320
+  },
+  originalimage: {
+    source: "https://upload.wikimedia.org/wikipedia/commons/9/95/Poire_Willermoz.jpg",
+    width: 644,
+    height: 856
+  },
+  lang: "en",
+  description: "branch of botany that studies and cultivates fruit",
+  extract: "Pomology is a branch of botany that studies and cultivates fruit. The denomination fruticulture—introduced from Romance languages —is also used.",
+  extract_html: "<p><b>Pomology</b> is a branch of botany that studies and cultivates fruit. The denomination <b>fruticulture</b>—introduced from Romance languages —is also used.</p>"
 }
 ```
 

--- a/test.js
+++ b/test.js
@@ -2,13 +2,12 @@ const lookup = require('.')
 
 test('happy path for a known word', async () => {
   const result = await lookup('pomology')
-  expect(Object.keys(result)).toEqual([
-    'query', 
-    'html', 
-    'text'
-  ])
-  expect(result.html.includes('<b>')).toBe(true)
-  expect(result.text.includes('<b>')).toBe(false)
+  const keys = Object.keys(result)
+  expect(result).toHaveProperty('query', 'pomology')
+  expect(result).toHaveProperty('title', 'Pomology')
+  expect(result).toHaveProperty('description')
+  expect(result).toHaveProperty('extract')
+  expect(result).toHaveProperty('extract_html')
 })
 
 test('unhappy path with a nonexistent term', async () => {
@@ -17,6 +16,6 @@ test('unhappy path with a nonexistent term', async () => {
 })
 
 test('alternate languages', async () => {
-  const result = await lookup('muñeca', 'es')
-  expect(result.text).toMatch('Una muñeca es una figura')
+  const result = await lookup('Muñeca', 'es')
+  expect(result.extract).toMatch('Una muñeca es una figura')
 })


### PR DESCRIPTION
He @jdlrobson 👋 

Now that I know about the Wikipedia Summary API, I can toss out the unreliable HTML-scraping approach formerly used by this module. 🎉 

Hitting a snag though: When doing a query with a special character in it like `muñeca`, I get a 400 error:

<details>
    { HTTPError: Response code 400 (Bad Request)
        at stream.catch.then.data (/Users/z/git/words/wikipedia-tldr/node_modules/got/index.js:341:13)
        at <anonymous>
        at process._tickCallback (internal/process/next_tick.js:188:7)
      name: 'HTTPError',
      host: 'es.wikipedia.org',
      hostname: 'es.wikipedia.org',
      method: 'GET',
      path: '/api/rest_v1/page/summary/Muñeca',
      protocol: 'https:',
      url: 'https://es.wikipedia.org/api/rest_v1/page/summary/Muñeca',
      statusCode: 400,
      statusMessage: 'Bad Request',
      headers: 
       { date: 'Sat, 12 May 2018 06:24:22 GMT',
         'content-type': 'application/problem+json',
         'content-length': '172',
         connection: 'close',
         'content-location': 'https://es.wikipedia.org/api/rest_v1/page/summary/Mu%25F1eca',
         'access-control-allow-origin': '*',
         'access-control-allow-methods': 'GET,HEAD',
         'access-control-allow-headers': 'accept, content-type, content-length, cache-control, accept-language, api-user-agent, if-match, if-modified-since, if-none-match, dnt, accept-encoding',
         'access-control-expose-headers': 'etag',
         'x-content-type-options': 'nosniff',
         'x-frame-options': 'SAMEORIGIN',
         'referrer-policy': 'origin-when-cross-origin',
         'x-xss-protection': '1; mode=block',
         'content-security-policy': 'default-src \'none\'; frame-ancestors \'none\'',
         'x-content-security-policy': 'default-src \'none\'; frame-ancestors \'none\'',
         'x-webkit-csp': 'default-src \'none\'; frame-ancestors \'none\'',
         'cache-control': 'private, max-age=0, s-maxage=0, must-revalidate',
         'x-request-id': '1bee36c6-55ad-11e8-b33e-98eb3e8befd2',
         server: 'restbase1011',
         'x-varnish': '544595303, 476608204, 903378207, 972304234',
         via: '1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)',
         age: '0',
         'x-cache': 'cp1067 pass, cp2004 pass, cp4029 pass, cp4027 pass',
         'x-cache-status': 'pass',
         'strict-transport-security': 'max-age=106384710; includeSubDomains; preload',
         'set-cookie': 
          [ 'WMF-Last-Access=12-May-2018;Path=/;HttpOnly;secure;Expires=Wed, 13 Jun 2018 00:00:00 GMT',
            'WMF-Last-Access-Global=12-May-2018;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Wed, 13 Jun 2018 00:00:00 GMT',
            'GeoIP=US:CA:Moorpark:34.31:-118.88:v4; Path=/; secure; Domain=.wikipedia.org' ],
         'x-analytics': 'https=1;nocookies=1',
         'x-client-ip': '99.175.68.19' } }
</details>

Example URL: https://es.wikipedia.org/api/rest_v1/page/summary/Muñeca

However if I open this URL in the browser, I see results. Any idea what might be wrong? At first I thought it was the redirect from lowercase `muñeca` to `muñeca` but [got](https://ghub.io/got) follows redirects. So that's not it.

Any ideas?

Resolves #2 