### PR TITLE
fix(CLI): Re-add the wordwrap dependency

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,6 @@ async function main () {
   }
   const result = await lookup(query)
 
-  console.log(result)
   if (result) {
     console.log(`\x1b[33m%s\x1b[0m`, wrap(`${result.title}: ${result.description}`))
     console.log(wrap(result.extract))

--- a/cli.js
+++ b/cli.js
@@ -10,8 +10,11 @@ async function main () {
     return
   }
   const result = await lookup(query)
+
+  console.log(result)
   if (result) {
-    console.log(wrap(result.text))
+    console.log(`\x1b[33m%s\x1b[0m`, wrap(`${result.title}: ${result.description}`))
+    console.log(wrap(result.extract))
   } else {
     console.log('no results :[')
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.1"
+        "node-fetch": "^2.6.1",
+        "wordwrap": "^1.0.0"
       },
       "bin": {
         "tldr": "cli.js",
@@ -9634,6 +9635,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -17342,6 +17348,11 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     ]
   },
   "dependencies": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "wordwrap": "^1.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -19,3 +19,25 @@ test('alternate languages', async () => {
   const result = await lookup('Muñeca', 'es')
   expect(result.extract).toMatch('Una muñeca es una figura')
 })
+
+
+// cli tests
+const { spawn } = require('child_process')
+
+test('cli', async (done) => {
+  const reverse = spawn('node', ['cli.js', 'pomology'])
+  const chunks = []
+
+  reverse.stdout.on('data', (chunk) => {
+    chunks.push(chunk)
+  });
+
+  reverse.stdout.on('end', () => {
+    const output = Buffer
+      .concat(chunks)
+      .toString()
+
+    expect(output).toContain('Pomology:')
+    done()
+  });
+});


### PR DESCRIPTION
@zeke `result.text` is not a thing (anymore?),  was it at some point? 

```js
{
  query: [ 'zymology' ],
  type: 'standard',
  title: 'Zymology',
  displaytitle: 'Zymology',
  wikibase_item: 'Q2703919',
  thumbnail: {
    source: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Wye_Valley_fermenter.jpg/320px-Wye_Valley_fermenter.jpg',
    width: 320,
    height: 240
  },
  originalimage: {
    source: 'https://upload.wikimedia.org/wikipedia/commons/0/03/Wye_Valley_fermenter.jpg',
    width: 1280,
    height: 960
  },
  lang: 'en',
  description: 'study of fermentation and its uses',
  description_source: 'local',
  extract: 'Zymology, also known as zymurgy is an applied science which studies the biochemical process of fermentation and its practical uses. Common topics include the selection of fermenting yeast and bacteria species and their use in brewing, wine making, fermenting milk, and the making of other fermented foods.',
  extract_html: '<p><b>Zymology</b>, also known as <b>zymurgy</b> is an applied science which studies the biochemical process of fermentation and its practical uses. Common topics include the selection of fermenting yeast and bacteria species and their use in brewing, wine making, fermenting milk, and the making of other fermented foods.</p>'
}
```

made up something using: `title`, `description` and `extract`.

fixes #7 